### PR TITLE
fix: update TemplateResponse for Starlette 1.0

### DIFF
--- a/src/webterm/api/routes/terminal.py
+++ b/src/webterm/api/routes/terminal.py
@@ -21,7 +21,7 @@ async def index(request: Request):
     Returns:
         Rendered HTML template
     """
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html")
 
 
 @router.websocket("/ws/terminal")


### PR DESCRIPTION
## Summary

Fixes the 500 error when opening the webterm page (`GET /`).

## What happened

Starlette 1.0 changed the argument order for `TemplateResponse`.
The old way passes arguments in the wrong order, causing the server to crash.

## What changed

Updated `TemplateResponse` call to match the new Starlette 1.0 API.